### PR TITLE
Add compute layer with bastion and private EC2 infrastructure

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -21,11 +21,11 @@ jobs:
         include:
           - environment: dev
             component: networking
-            aws_region: ap-southeast-2
+            aws_region: ap-south-1
 
           - environment: dev
             component: compute
-            aws_region: ap-southeast-2
+            aws_region: ap-south-1
 
           # - environment: uat
           #   component: networking

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -23,9 +23,9 @@ jobs:
             component: networking
             aws_region: ap-south-1
 
-          - environment: dev
-            component: compute
-            aws_region: ap-south-1
+          # - environment: dev
+          #   component: compute
+          #   aws_region: ap-south-1
 
           # - environment: uat
           #   component: networking

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -9,9 +9,43 @@ on:
 permissions:
   id-token: write
   contents: read
+  pull-requests: write
 
 jobs:
+  terraform-plan:
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+          - environment: dev
+            component: networking
+            aws_region: ap-southeast-2
+
+          - environment: dev
+            component: compute
+            aws_region: ap-southeast-2
+
+          # - environment: uat
+          #   component: networking
+          #   aws_region: ap-southeast-2
+
+    uses: bhowmickkrishnendu/terraform-gha-workflows/.github/workflows/terraform-plan.yml@main
+
+    with:
+      environment: ${{ matrix.environment }}
+      component: ${{ matrix.component }}
+      aws_region: ${{ matrix.aws_region }}
+      terraform_version: 1.14
+      tfvars_file: ${{ matrix.environment }}.tfvars
+      role_to_assume: arn:aws:iam::234617061868:role/github-actions-terraform-role
+
+    secrets:
+      INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}
+
   terraform-apply:
+    needs: terraform-plan
 
     strategy:
       fail-fast: false
@@ -37,5 +71,4 @@ jobs:
       component: ${{ matrix.component }}
       aws_region: ${{ matrix.aws_region }}
       terraform_version: 1.14
-      tfvars_file: ${{ matrix.environment }}.tfvars
       role_to_assume: arn:aws:iam::234617061868:role/github-actions-terraform-role

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -22,9 +22,9 @@ jobs:
             component: networking
             aws_region: ap-southeast-2
 
-          # - environment: dev
-          #   component: security
-          #   aws_region: ap-southeast-2
+          - environment: dev
+            component: compute
+            aws_region: ap-southeast-2
 
           # - environment: uat
           #   component: networking

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -11,13 +11,31 @@ permissions:
   contents: read
 
 jobs:
-  networking-dev:
+  terraform-apply:
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+          - environment: dev
+            component: networking
+            aws_region: ap-southeast-2
+
+          # - environment: dev
+          #   component: security
+          #   aws_region: ap-southeast-2
+
+          # - environment: uat
+          #   component: networking
+          #   aws_region: ap-southeast-2
+
     uses: bhowmickkrishnendu/terraform-gha-workflows/.github/workflows/terraform-apply.yml@main
 
     with:
-      environment: dev
-      component: networking
-      aws_region: ap-southeast-2
+      environment: ${{ matrix.environment }}
+      component: ${{ matrix.component }}
+      aws_region: ${{ matrix.aws_region }}
       terraform_version: 1.14
-      tfvars_file: dev.tfvars
+      tfvars_file: ${{ matrix.environment }}.tfvars
       role_to_assume: arn:aws:iam::234617061868:role/github-actions-terraform-role

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -18,7 +18,7 @@ on:
         type: choice
         options:
           - networking
-          # - security
+          - compute
           # - ecr
 
       confirm_destroy:

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -3,6 +3,24 @@ name: Terraform Destroy
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        description: "Environment"
+        required: true
+        type: choice
+        options:
+          - dev
+          # - uat
+          # - prod
+
+      component:
+        description: "Component"
+        required: true
+        type: choice
+        options:
+          - networking
+          # - security
+          # - ecr
+
       confirm_destroy:
         description: "Type DESTROY to continue"
         required: true
@@ -12,13 +30,13 @@ permissions:
   contents: read
 
 jobs:
-  networking-dev:
+  terraform-destroy:
     uses: bhowmickkrishnendu/terraform-gha-workflows/.github/workflows/terraform-destroy.yml@main
 
     with:
-      environment: dev
-      component: networking
+      environment: ${{ github.event.inputs.environment }}
+      component: ${{ github.event.inputs.component }}
       aws_region: ap-southeast-2
-      tfvars_file: dev.tfvars
+      tfvars_file: ${{ github.event.inputs.environment }}.tfvars
       confirm_destroy: ${{ github.event.inputs.confirm_destroy }}
       role_to_assume: arn:aws:iam::234617061868:role/github-actions-terraform-role

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -23,9 +23,9 @@ jobs:
             component: networking
             aws_region: ap-southeast-2
 
-          # - environment: dev
-          #   component: security
-          #   aws_region: ap-southeast-2
+          - environment: dev
+            component: compute
+            aws_region: ap-southeast-2
 
           # - environment: uat
           #   component: networking

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -23,9 +23,9 @@ jobs:
             component: networking
             aws_region: ap-south-1
 
-          - environment: dev
-            component: compute
-            aws_region: ap-south-1
+          # - environment: dev
+          #   component: compute
+          #   aws_region: ap-south-1
 
           # - environment: uat
           #   component: networking

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -12,15 +12,33 @@ permissions:
   pull-requests: write
 
 jobs:
-  networking-dev:
+  terraform-plan:
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+          - environment: dev
+            component: networking
+            aws_region: ap-southeast-2
+
+          # - environment: dev
+          #   component: security
+          #   aws_region: ap-southeast-2
+
+          # - environment: uat
+          #   component: networking
+          #   aws_region: ap-southeast-2
+
     uses: bhowmickkrishnendu/terraform-gha-workflows/.github/workflows/terraform-plan.yml@main
 
     with:
-      environment: dev
-      component: networking
-      aws_region: ap-southeast-2
+      environment: ${{ matrix.environment }}
+      component: ${{ matrix.component }}
+      aws_region: ${{ matrix.aws_region }}
       terraform_version: 1.14
-      tfvars_file: dev.tfvars
+      tfvars_file: ${{ matrix.environment }}.tfvars
       role_to_assume: arn:aws:iam::234617061868:role/github-actions-terraform-role
 
     secrets:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -21,15 +21,15 @@ jobs:
         include:
           - environment: dev
             component: networking
-            aws_region: ap-southeast-2
+            aws_region: ap-south-1
 
           - environment: dev
             component: compute
-            aws_region: ap-southeast-2
+            aws_region: ap-south-1
 
           # - environment: uat
           #   component: networking
-          #   aws_region: ap-southeast-2
+          #   aws_region: ap-south-1
 
     uses: bhowmickkrishnendu/terraform-gha-workflows/.github/workflows/terraform-plan.yml@main
 

--- a/environments/dev/compute/backend.tf
+++ b/environments/dev/compute/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "krish-terraform-state-ap-south-1"
+    key          = "dev/compute/terraform.tfstate"
+    region       = "ap-south-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/environments/dev/compute/dev.tfvars
+++ b/environments/dev/compute/dev.tfvars
@@ -3,4 +3,4 @@ environment = "dev"
 
 instance_type = "t3.micro"
 
-# public_key = "PASTE-YOUR-PUBLIC-KEY-HERE"
+# public_key = "PASTE-YOUR-PUBLIC-KEY-HERE."

--- a/environments/dev/compute/dev.tfvars
+++ b/environments/dev/compute/dev.tfvars
@@ -2,3 +2,5 @@ aws_region  = "ap-south-1"
 environment = "dev"
 
 instance_type = "t3.micro"
+
+# public_key = "PASTE-YOUR-PUBLIC-KEY-HERE"

--- a/environments/dev/compute/dev.tfvars
+++ b/environments/dev/compute/dev.tfvars
@@ -1,0 +1,4 @@
+aws_region  = "ap-south-1"
+environment = "dev"
+
+instance_type = "t3.micro"

--- a/environments/dev/compute/main.tf
+++ b/environments/dev/compute/main.tf
@@ -1,0 +1,162 @@
+data "terraform_remote_state" "networking" {
+  backend = "s3"
+
+  config = {
+    bucket = "krish-terraform-state-ap-south-1"
+    key    = "dev/networking/terraform.tfstate"
+    region = "ap-south-1"
+  }
+}
+
+resource "aws_key_pair" "deployer" {
+  key_name = "${var.environment}-key"
+
+  public_key = file("C:/Users/Krish/.ssh/id_rsa.pub")
+}
+
+resource "aws_security_group" "bastion_sg" {
+  name        = "${var.environment}-bastion-sg"
+  description = "Security group for bastion host"
+  vpc_id      = data.terraform_remote_state.networking.outputs.vpc_id
+
+  ingress {
+    description = "SSH Access"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "${var.environment}-bastion-sg"
+    Environment = var.environment
+  }
+}
+
+
+module "bastion" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 6.0"
+
+  name = "${var.environment}-bastion"
+
+  instance_type = var.instance_type
+
+  ami = "ami-0f58b397bc5c1f2e8"
+
+  subnet_id = data.terraform_remote_state.networking.outputs.public_subnets[0]
+
+  key_name = aws_key_pair.deployer.key_name
+
+  vpc_security_group_ids = [
+    aws_security_group.bastion_sg.id
+  ]
+
+  associate_public_ip_address = true
+
+  tags = {
+    Name        = "${var.environment}-bastion"
+    Environment = var.environment
+  }
+}
+
+resource "aws_security_group" "private_ec2_sg" {
+  name        = "${var.environment}-private-ec2-sg"
+  description = "Security group for private EC2"
+  vpc_id      = data.terraform_remote_state.networking.outputs.vpc_id
+
+  ingress {
+    description = "SSH from bastion"
+
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+
+    security_groups = [
+      aws_security_group.bastion_sg.id
+    ]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "${var.environment}-private-ec2-sg"
+    Environment = var.environment
+  }
+}
+
+
+resource "aws_iam_role" "ec2_ssm_role" {
+  name = "${var.environment}-ec2-ssm-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+
+    Statement = [
+      {
+        Effect = "Allow"
+
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.ec2_ssm_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ec2_profile" {
+  name = "${var.environment}-ec2-profile"
+  role = aws_iam_role.ec2_ssm_role.name
+}
+
+
+module "private_ec2" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 6.0"
+
+  name = "${var.environment}-private-ec2"
+
+  instance_type = var.instance_type
+
+  ami = "ami-0f58b397bc5c1f2e8"
+
+  subnet_id = data.terraform_remote_state.networking.outputs.private_subnets[0]
+
+  key_name = aws_key_pair.deployer.key_name
+
+  vpc_security_group_ids = [
+    aws_security_group.private_ec2_sg.id
+  ]
+
+  associate_public_ip_address = false
+
+  iam_instance_profile = aws_iam_instance_profile.ec2_profile.name
+
+  tags = {
+    Name        = "${var.environment}-private-ec2"
+    Environment = var.environment
+  }
+}
+

--- a/environments/dev/compute/main.tf
+++ b/environments/dev/compute/main.tf
@@ -11,7 +11,7 @@ data "terraform_remote_state" "networking" {
 resource "aws_key_pair" "deployer" {
   key_name = "${var.environment}-key"
 
-  public_key = file("C:/Users/Krish/.ssh/id_rsa.pub")
+  public_key = var.public_key
 }
 
 resource "aws_security_group" "bastion_sg" {

--- a/environments/dev/compute/outputs.tf
+++ b/environments/dev/compute/outputs.tf
@@ -1,0 +1,15 @@
+output "bastion_public_ip" {
+  value = module.bastion.public_ip
+}
+
+output "bastion_instance_id" {
+  value = module.bastion.id
+}
+
+output "private_ec2_instance_id" {
+  value = module.private_ec2.id
+}
+
+output "private_ec2_private_ip" {
+  value = module.private_ec2.private_ip
+}

--- a/environments/dev/compute/provider.tf
+++ b/environments/dev/compute/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/environments/dev/compute/variables.tf
+++ b/environments/dev/compute/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "instance_type" {
+  type = string
+}

--- a/environments/dev/compute/variables.tf
+++ b/environments/dev/compute/variables.tf
@@ -9,3 +9,8 @@ variable "environment" {
 variable "instance_type" {
   type = string
 }
+
+variable "public_key" {
+  type      = string
+  sensitive = true
+}

--- a/environments/dev/compute/versions.tf
+++ b/environments/dev/compute/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/environments/dev/s3/provider.tf
+++ b/environments/dev/s3/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region = var.aws_region
+  # profile = var.aws_profile
+}

--- a/environments/dev/s3/provider.tf
+++ b/environments/dev/s3/provider.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  region = var.aws_region
-  # profile = var.aws_profile
-}


### PR DESCRIPTION
## Changes Included

- Added compute layer Terraform stack
- Added bastion EC2 instance
- Added private EC2 instance
- Added SSH key pair integration
- Added IAM role for SSM access
- Added security groups for bastion/private access
- Configured remote state dependency with networking stack
- Added backend configuration for compute state

## Validation

- terraform fmt
- terraform validate
- terraform plan