### PR TITLE
feat: support per-instance dynamic user_data via external scripts

### DIFF
--- a/environments/dev/compute/dev.tfvars
+++ b/environments/dev/compute/dev.tfvars
@@ -17,6 +17,8 @@ instance_definitions = {
     associate_public_ip_address = true
     use_iam_profile             = true
     extra_tags                  = { Role = "bastion" }
+    user_data_file              = "scripts/bastion.sh"
+    user_data_vars              = { hostname = "dev-bastion" }
     extra_ebs = {
       data1 = {
         device_name           = "/dev/sdb"
@@ -36,6 +38,7 @@ instance_definitions = {
     associate_public_ip_address = false
     use_iam_profile             = true
     extra_tags                  = { Role = "app" }
+    user_data_file              = "scripts/private_ec2.sh"
     extra_ebs                   = {}
   }
 }

--- a/environments/dev/compute/locals.tf
+++ b/environments/dev/compute/locals.tf
@@ -1,0 +1,40 @@
+locals {
+  # Per-instance EBS-mount script. Non-empty only when extra_ebs is a map whose
+  # entries declare both device_name and mount_point. (Mirrors the previous inline logic.)
+  ebs_mount_scripts = {
+    for k, def in var.instance_definitions : k => (
+      can(keys(lookup(def, "extra_ebs", {}))) ? join("\n", [
+        for v in values(lookup(def, "extra_ebs", {})) :
+        format(
+          "if [ -b %s ]; then mkfs -t %s %s || true; mkdir -p %s; mount %s %s; echo '%s %s %s defaults,nofail 0 2' >> /etc/fstab; fi",
+          v.device_name, coalesce(v.filesystem, "ext4"), v.device_name, v.mount_point,
+          v.device_name, v.mount_point, v.device_name, v.mount_point, coalesce(v.filesystem, "ext4")
+        )
+        if v.mount_point != null && v.mount_point != "" && v.device_name != null && v.device_name != ""
+      ]) : ""
+    )
+  }
+
+  # Per-instance custom bootstrap, rendered from user_data_file via templatefile().
+  custom_user_data = {
+    for k, def in var.instance_definitions : k => (
+      def.user_data_file != null && def.user_data_file != ""
+      ? templatefile("${path.module}/${def.user_data_file}", def.user_data_vars)
+      : ""
+    )
+  }
+
+  # Final merged user_data: shebang, then auto EBS mount, then the custom script.
+  # null when neither part has content (so the module omits user_data entirely).
+  instance_user_data = {
+    for k, def in var.instance_definitions : k => (
+      local.ebs_mount_scripts[k] == "" && local.custom_user_data[k] == ""
+      ? null
+      : join("\n", concat(
+        ["#!/bin/bash", "set -e"],
+        local.ebs_mount_scripts[k] == "" ? [] : ["# --- auto EBS mount ---", local.ebs_mount_scripts[k]],
+        local.custom_user_data[k] == "" ? [] : ["# --- custom user_data ---", local.custom_user_data[k]]
+      ))
+    )
+  }
+}

--- a/environments/dev/compute/main.tf
+++ b/environments/dev/compute/main.tf
@@ -111,8 +111,9 @@ module "instances" {
     )
   )
 
-  # Generate user_data only when `extra_ebs` is a map with explicit device_name and mount_point.
-  user_data = can(keys(lookup(each.value, "extra_ebs", {}))) && length([for v in values(lookup(each.value, "extra_ebs", {})) : v.mount_point != null && v.mount_point != "" && v.device_name != null && v.device_name != "" ? 1 : 0]) > 0 ? join("\n", concat(["#!/bin/bash", "set -e"], [for v in values(lookup(each.value, "extra_ebs", {})) : v.mount_point != null && v.mount_point != "" && v.device_name != null && v.device_name != "" ? format("if [ -b %s ]; then mkfs -t %s %s || true; mkdir -p %s; mount %s %s; echo '%s %s %s defaults,nofail 0 2' >> /etc/fstab; fi", v.device_name, coalesce(v.filesystem, "ext4"), v.device_name, v.mount_point, v.device_name, v.mount_point, v.device_name, v.mount_point, coalesce(v.filesystem, "ext4")) : ""])) : null
+  # Per-instance bootstrap: auto EBS-mount script merged with the custom user_data_file.
+  # See locals.tf for how local.instance_user_data is assembled.
+  user_data = local.instance_user_data[each.key]
 
   tags = merge({ Name = "${var.environment}-${each.key}", Environment = var.environment }, coalesce(each.value.extra_tags, {}))
 }

--- a/environments/dev/compute/scripts/bastion.sh
+++ b/environments/dev/compute/scripts/bastion.sh
@@ -1,0 +1,9 @@
+# Custom bootstrap for the bastion host.
+# NOTE: do not add a "#!/bin/bash" line here — it is prepended automatically
+# along with the EBS-mount script (this content is appended after both).
+
+# Example: install basic tooling and set hostname from a templatefile var.
+yum update -y
+yum install -y htop tmux
+
+hostnamectl set-hostname "${hostname}"

--- a/environments/dev/compute/scripts/private_ec2.sh
+++ b/environments/dev/compute/scripts/private_ec2.sh
@@ -1,0 +1,6 @@
+# Custom bootstrap for the private app instance.
+# NOTE: no shebang here — it is added automatically by locals.tf.
+
+yum update -y
+yum install -y nginx
+systemctl enable --now nginx

--- a/environments/dev/compute/variables.tf
+++ b/environments/dev/compute/variables.tf
@@ -63,6 +63,11 @@ variable "instance_definitions" {
     associate_public_ip_address = bool
     use_iam_profile             = bool
     extra_tags                  = optional(map(string))
+    # Per-instance bootstrap script. Path is relative to this module and rendered
+    # with `user_data_vars` via templatefile(). The EBS-mount script (when extra_ebs
+    # defines mount points) is prepended automatically.
+    user_data_file = optional(string)
+    user_data_vars = optional(map(string), {})
     extra_ebs = optional(map(object({
       size                  = optional(number)
       type                  = optional(string)


### PR DESCRIPTION
Add optional user_data_file/user_data_vars to instance_definitions so each EC2 can supply its own bootstrap script (rendered with templatefile). The auto EBS-mount script is now merged ahead of the custom script in a new locals.tf, replacing the inline user_data expression in main.tf.